### PR TITLE
Reordering list of projects so that first part of list isn't dominated by the 3 cmgui/Zinc projects, which are basically currently the same project.

### DIFF
--- a/_themes/physiome/templates/home.html
+++ b/_themes/physiome/templates/home.html
@@ -7,25 +7,9 @@
 <ul class="projects-carousel clearfix">
 
 	<li>
-		<a href="/software/zincplugin/">
-			<img src="/assets/img/software/zincplugin/220x140/zincplugin-hearts.png" alt="">
-			<h5 class="title">Zinc plugin</h5>
-			<span class="categories">&nbsp;</span>
-		</a>
-  	</li>
-
-	<li>
 	  <a href="/software/zinclibrary/">
 			<img src="/assets/img/software/zinclibrary/220x140/zinclibrary-bone.png" alt="">
 			<h5 class="title">Zinc library</h5>
-			<span class="categories">&nbsp;</span>
-		</a>
-  	</li>
-
-	<li>
-	  <a href="/software/cmgui/">
-			<img src="/assets/img/software/cmgui/220x140/cmgui-fitting.png" alt="">
-			<h5 class="title">Cmgui</h5>
 			<span class="categories">&nbsp;</span>
 		</a>
   	</li>
@@ -58,6 +42,22 @@
 	  <a href="/software/opencell/">
 			<img src="/assets/img/software/opencell/220x140/opencell-graph.png" alt="">
 			<h5 class="title">OpenCell</h5>
+			<span class="categories">&nbsp;</span>
+		</a>
+  	</li>
+
+	<li>
+	  <a href="/software/cmgui/">
+			<img src="/assets/img/software/cmgui/220x140/cmgui-fitting.png" alt="">
+			<h5 class="title">Cmgui</h5>
+			<span class="categories">&nbsp;</span>
+		</a>
+  	</li>
+
+	<li>
+		<a href="/software/zincplugin/">
+			<img src="/assets/img/software/zincplugin/220x140/zincplugin-hearts.png" alt="">
+			<h5 class="title">Zinc plugin</h5>
 			<span class="categories">&nbsp;</span>
 		</a>
   	</li>


### PR DESCRIPTION
Zinc,Zinc plugin and Cmgui are all very close projects, it makes sense to just have one of them in the first 4, so that the first part of the list of projects gives a broader sense of the projects (depending on the browser window size, only the first one, two, three or four items from the list are displayed).
