### PR TITLE
Remove trailing slashes / from internal links

### DIFF
--- a/_content/04-software/01-opencmiss/02-zinc/03-documentation/01-api-reference/capi.md
+++ b/_content/04-software/01-opencmiss/02-zinc/03-documentation/01-api-reference/capi.md
@@ -16,7 +16,7 @@ intro:
 
 		<header class="page-header clearfix">
 			<h1 class="page-title align-left">PyZinc library tutorials</h1>		
-			<a href="/software/" class="button no-bg medium align-right">
+			<a href="/software" class="button no-bg medium align-right">
 				All software projects <img src="/img/icon-grid.png" alt="" class="icon">
 			</a>			
 		</header><!-- end .page-header --><!-- end .page-header -->

--- a/_content/04-software/01-opencmiss/02-zinc/03-documentation/02-tutorials/page.md
+++ b/_content/04-software/01-opencmiss/02-zinc/03-documentation/02-tutorials/page.md
@@ -16,7 +16,7 @@ intro:
 
 		<header class="page-header clearfix">
 			<h1 class="page-title align-left">PyZinc library tutorials</h1>		
-			<a href="/software/" class="button no-bg medium align-right">
+			<a href="/software" class="button no-bg medium align-right">
 				All software projects <img src="/img/icon-grid.png" alt="" class="icon">
 			</a>			
 		</header><!-- end .page-header --><!-- end .page-header -->

--- a/_content/04-software/01-opencmiss/02-zinc/03-documentation/04-support/page.md
+++ b/_content/04-software/01-opencmiss/02-zinc/03-documentation/04-support/page.md
@@ -9,7 +9,7 @@ intro: >
 navtitle: OpenCMISS-Zinc Support
 ---
 
-If you cannot find the information you need from the [Zinc Documentation](..), or you encounter bugs or you wish to request new features, please use the following links.
+If you cannot find the information you need from the [Zinc Documentation](../documentation), or you encounter bugs or you wish to request new features, please use the following links.
 
 ### Mailing List
 

--- a/_content/04-software/01-opencmiss/02-zinc/03-documentation/page.md
+++ b/_content/04-software/01-opencmiss/02-zinc/03-documentation/page.md
@@ -11,18 +11,18 @@ navtitle:
 <p>The best way to learn Zinc is to work through examples that achieve a similar objective to what you need. The tutorials are designed to get you started and provide detailed explanations of concepts and how Zinc works. At any stage users can get an overview of the library and its concepts from the introduction in the API reference, and look up the detailed descriptions of API methods in that section.
 </p>
 <div class="one-fourth">
-<h5><a href="/software/opencmiss/zinc/documentation/api-reference/">API Reference</a></h5>
+<h5><a href="/software/opencmiss/zinc/documentation/api-reference">API Reference</a></h5>
 <p>An introduction to the Zinc library and the objects and concepts behind its API, and API reference documentation including all methods, arguments and return values.</p>
 </div><!-- end .one-fourth -->
 <div class="one-fourth">
-<h5><a href="/software/opencmiss/zinc/documentation/tutorials/">Tutorials</a></h5>
+<h5><a href="/software/opencmiss/zinc/documentation/tutorials">Tutorials</a></h5>
 <p>Walk-through tutorials for getting started with Zinc, introducing concepts and techniques in small steps, with thorough explanations.</p>
 </div><!-- end .one-fourth -->
 <div class="one-fourth">
-<h5><a href="/software/opencmiss/zinc/documentation/examples/">Examples</a></h5>
+<h5><a href="/software/opencmiss/zinc/documentation/examples">Examples</a></h5>
 <p>A collection of objective-based and advanced examples using the Zinc library that may be copied to integrate into your code.</p>
 </div><!-- end .one-fourth -->
 <div class="one-fourth last">
-<h5><a href="/software/opencmiss/zinc/documentation/support/">Support</a></h5>
+<h5><a href="/software/opencmiss/zinc/documentation/support">Support</a></h5>
 <p>Where to get additional support, provide feedback and request features.</p>
 </div><!-- end .one-fourth last -->

--- a/_content/04-software/01-opencmiss/03-cmgui/01-about/page.md
+++ b/_content/04-software/01-opencmiss/03-cmgui/01-about/page.md
@@ -16,7 +16,7 @@ Cmgui also contains graphics conversion operations for making field visualisatio
 ### The Zinc plugin
 
 A major part of the cmgui project has been the development of a unique web browser extension or plug-in called ZINC for viewing and interacting with cmgui scenes on the web. While cmgui began as a standalone programme, the focus is now on further developing the cmgui library for independent software developers wishing to describe their models and visualise graphics.
-<ul class="arrow-2 dotted"><li><a href="/software/zincplugin/">Find out more about the Zinc plugin</a></li></ul>
+<ul class="arrow-2 dotted"><li><a href="/software/zincplugin">Find out more about the Zinc plugin</a></li></ul>
 
 ### Developers and Contributors
 

--- a/_content/04-software/01-opencmiss/03-cmgui/05-related-software/page.md
+++ b/_content/04-software/01-opencmiss/03-cmgui/05-related-software/page.md
@@ -5,7 +5,7 @@ _fieldset: page
 title: Related software
 ---
 There are three major Physiome Project software packages that are closely related to Cmgui. These software packages are focused on the following areas:
-<ul class="arrow dotted"><li><a href="/software/cm/">CM</a> is used for computational modelling </li><li><a href="http://www.cmiss.org/cmgui/wiki/Unemap" title="" style="background-color:;">Unemap</a> is used for signal acquisition and processing</li><li>Cmgui is used for model visualisation and manipulation</li></ul>
+<ul class="arrow dotted"><li><a href="/software/cm">CM</a> is used for computational modelling </li><li><a href="http://www.cmiss.org/cmgui/wiki/Unemap" title="" style="background-color:;">Unemap</a> is used for signal acquisition and processing</li><li>Cmgui is used for model visualisation and manipulation</li></ul>
 
 ###Solving complex bioengineering problems 
 
@@ -23,4 +23,4 @@ Cmgui is also used as part of the Zinc pugin to Mozilla Firefox. The Zinc extens
 <ul class="check dotted"><li>Interactively explore colon endoscopy</li><li>Explore the Physiome eye model</li><li>Create data points to give a digital description of a geometry based on medical images</li></ul>
 
 Note that the Zinc plugin is compiled as a separate application from Cmgui.  You do _not_ have to install Cmgui to use Zinc.
-<ul class="arrow-2 dotted"><li><a href="/software/zincplugin/">Find out more about the  Zinc plugin</a></li></ul>
+<ul class="arrow-2 dotted"><li><a href="/software/zincplugin">Find out more about the  Zinc plugin</a></li></ul>

--- a/_content/04-software/05-cm/05-related-software/page.md
+++ b/_content/04-software/05-cm/05-related-software/page.md
@@ -12,4 +12,4 @@ navtitle: Related Physiome Project software
 ---
 Two other Physiome Project software packages are closely related to CM:
 
-<ul class="arrow dotted"> <li><a href="/software/cmgui/">Cmgui</a> is used to visualize the results of solutions computed with CM</li> <li><a href="/software/opencmiss/">OpenCMISS</a> is an open-source re-write of CM, aimed at providing maximum performance on modern compute hardware.</li> </ul>
+<ul class="arrow dotted"> <li><a href="/software/cmgui">Cmgui</a> is used to visualize the results of solutions computed with CM</li> <li><a href="/software/opencmiss">OpenCMISS</a> is an open-source re-write of CM, aimed at providing maximum performance on modern compute hardware.</li> </ul>

--- a/_content/04-software/page.md
+++ b/_content/04-software/page.md
@@ -17,45 +17,45 @@ gallerylinks:
   -
     image_title: OpenCMISS-Zinc
     image_loc: /assets/img/software/zinclibrary/220x140/zinclibrary-bone.png
-    image_link: /software/opencmiss/zinc/
+    image_link: /software/opencmiss/zinc
     image_caption: >
       A library for building interactive modelling and 3-D visualisation applications.
   -
     image_title: Cmgui
     image_loc: /assets/img/software/cmgui/220x140/cmgui-fitting.png
-    image_dimensions: width="220"
-    image_link: /software/opencmiss/cmgui/
+    image_dimensions:
+    image_link: /software/opencmiss/cmgui
     image_caption: >
       Standalone application for visualising and interacting with mathematical field models.
   -
     image_title: CMISS-cm
     image_loc: /assets/img/software/cm/220x140/leg-model.png
-    image_link: /software/cm/
+    image_link: /software/cm
     image_caption: >
       Original application for Continuum Mechanics, Image analysis, Signal processing and System identification.
   -
     image_title: CellML
     image_loc: /assets/img/software/cellml/220x140/cell-diagram.png
-    image_link: /software/cellml/
+    image_link: /software/cellml
     image_caption: >
       The XML language and API for storing and exchanging mathematical models of biological systems.
   -
     image_title: OpenCOR
     image_loc: /assets/img/software/opencor/220x140/opencor-ui-graph.png
-    image_link: http://opencor.ws/
-    image_dimensions: width="220"
+    image_link: http://opencor.ws
+    image_dimensions:
     image_caption: >
       A cross-platform modelling environment used to organise, edit, simulate and analyse CellML files.
   -
     image_title: OpenCell
     image_loc: /assets/img/software/opencell/220x140/opencell-graph.png
-    image_link: /software/opencell/
+    image_link: /software/opencell
     image_caption: >
       A free, open source environment for working with CellML.
   -
     image_title: FieldML
     image_loc: /assets/img/software/fieldml/220x140/fieldml-bifurc.png
-    image_link: /software/fieldml/
+    image_link: /software/fieldml
     image_caption: >
       An XML language and API for mathematical field model interchange.
 ---

--- a/_themes/physiome/layouts/404.html
+++ b/_themes/physiome/layouts/404.html
@@ -15,7 +15,7 @@
 	<article>
 
 		<header class="page-header">
-			<h1 class="topic-title"><a href="/about/">The IUPS Physiome Project</a></h1>
+			<h1 class="topic-title"><a href="/about">The IUPS Physiome Project</a></h1>
 		</header><!-- end .page-header -->
 
 		<div id="main">

--- a/_themes/physiome/layouts/about-page.html
+++ b/_themes/physiome/layouts/about-page.html
@@ -15,7 +15,7 @@
 	<article>
 
 		<header class="page-header">
-			<h1 class="topic-title"><a href="/about/">About the IUPS Physiome Project</a></h1>
+			<h1 class="topic-title"><a href="/about">About the IUPS Physiome Project</a></h1>
 		</header><!-- end .page-header -->
 
 		<div id="main">

--- a/_themes/physiome/layouts/meetings-index.html
+++ b/_themes/physiome/layouts/meetings-index.html
@@ -103,7 +103,7 @@
 			<h5><a href="http://www.elsevier.com/">Elsevier</a></h5>
 		</div><!-- end .one-fourth -->
 		<div class="one-fourth">
-		    <a href="http://www.icsu.org/"><img src="/assets/img/meetings/sponsor-logos/logo-icsu.png" alt="A computer model of the eye." width="220" height="140"></a>
+		    <a href="http://www.icsu.org/"><img src="/assets/img/meetings/sponsor-logos/logo-icsu.png" width="220" height="140"></a>
 			<h5><a href="http://www.icsu.org/">International Council for Science</a></h5>
 		</div><!-- end .one-fourth -->
 		<div class="one-fourth last"> <a href="http://www.iubmb.org/">

--- a/_themes/physiome/layouts/meetings-page.html
+++ b/_themes/physiome/layouts/meetings-page.html
@@ -15,7 +15,7 @@
 	<article>
 
 		<header class="page-header">
-			<h1 class="topic-title"><a href="/meetings/">ICSU bio-unions satellite symposium</a></h1>
+			<h1 class="topic-title"><a href="/meetings">ICSU bio-unions satellite symposium</a></h1>
 		</header><!-- end .page-header -->
 
 		<div id="main">

--- a/_themes/physiome/layouts/research-page.html
+++ b/_themes/physiome/layouts/research-page.html
@@ -15,7 +15,7 @@
 	<article>
 
 		<header class="page-header">
-			<h1 class="topic-title"><a href="/research/">Research</a></h1>
+			<h1 class="topic-title"><a href="/research">Research</a></h1>
 		</header><!-- end .page-header -->
 
 		<div id="main">

--- a/_themes/physiome/layouts/software-download.html
+++ b/_themes/physiome/layouts/software-download.html
@@ -18,7 +18,7 @@
 		
 			{{ theme:partial src="software-download-section-title" project="{ segment_2 }" }}
 			
-			<a href="/software/" class="button no-bg medium align-right">
+			<a href="/software" class="button no-bg medium align-right">
 				All software projects <img src="/_themes/physiome/img/icon-grid.png" alt="" class="icon">
 			</a>
 

--- a/_themes/physiome/layouts/software-page.html
+++ b/_themes/physiome/layouts/software-page.html
@@ -21,7 +21,7 @@
 			<!--	{{ endif }}-->
 			<!--{{ /nav }}-->
 			
-			<a href="/software/" class="button no-bg medium align-right">
+			<a href="/software" class="button no-bg medium align-right">
 				All software projects <img src="/_themes/physiome/img/icon-grid.png" alt="" class="icon">
 			</a>
 

--- a/_themes/physiome/layouts/support-20130314.html
+++ b/_themes/physiome/layouts/support-20130314.html
@@ -15,8 +15,8 @@
 	<article class="single-project">
 
 		<header class="page-header clearfix">
-			<h1 class="page-title align-left"><a href="/software/zincplugin/">Zinc plugin</a></h1>
-			<a href="/software/" class="button no-bg medium align-right">
+			<h1 class="page-title align-left"><a href="/software/zincplugin">Zinc plugin</a></h1>
+			<a href="/software" class="button no-bg medium align-right">
 				All software projects <img src="/_themes/physiome/img/icon-grid.png" alt="" class="icon">
 			</a>			
 		</header><!-- end .page-header -->

--- a/_themes/physiome/layouts/support.html
+++ b/_themes/physiome/layouts/support.html
@@ -16,31 +16,31 @@
 
 		<header class="page-header clearfix">
 			{{ if segment_2 == "zinclibrary" }}
-			<h1 class="page-title align-left"><a href="/software/zinclibrary/">Zinc library</a></h1>
+			<h1 class="page-title align-left"><a href="/software/opencmiss/zinc">OpenCMISS-Zinc library</a></h1>
 			{{ elseif segment_2 == "zincplugin" }}
-			<h1 class="page-title align-left"><a href="/software/zincplugin/">Zinc plugin</a></h1>
+			<h1 class="page-title align-left"><a href="/software/zincplugin">Zinc plugin</a></h1>
 			{{ elseif segment_2 == "cmgui" }}
-			<h1 class="page-title align-left"><a href="/software/cmgui/">Cmgui</a></h1>
+			<h1 class="page-title align-left"><a href="/software/cmgui">Cmgui</a></h1>
 			{{ elseif segment_2 == "opencmiss" }}
-			<h1 class="page-title align-left"><a href="/software/opencmiss/">OpenCMISS</a></h1>
+			<h1 class="page-title align-left"><a href="/software/opencmiss">OpenCMISS</a></h1>
 
 			{{ elseif segment_2 == "cellml" }}
-			<h1 class="page-title align-left"><a href="/software/cellml/">CellML</a></h1>
+			<h1 class="page-title align-left"><a href="/software/cellml">CellML</a></h1>
 
 			{{ elseif segment_2 == "fieldml" }}
-			<h1 class="page-title align-left"><a href="/software/fieldml/">FieldML</a></h1>
+			<h1 class="page-title align-left"><a href="/software/fieldml">FieldML</a></h1>
 
 			{{ elseif segment_2 == "opencell" }}
-			<h1 class="page-title align-left"><a href="/software/opencell/">OpenCell</a></h1>
+			<h1 class="page-title align-left"><a href="/software/opencell">OpenCell</a></h1>
 
 			{{ elseif segment_2 == "cm" }}
-			<h1 class="page-title align-left"><a href="/software/cm/">CM</a></h1>
+			<h1 class="page-title align-left"><a href="/software/cm">CM</a></h1>
 
 			{{ elseif segment_2 == "pyzinc" }}
-			<h1 class="page-title align-left"><a href="/software/pyzinc/">PyZinc</a></h1>
+			<h1 class="page-title align-left"><a href="/software/pyzinc">PyZinc</a></h1>
 
 			{{ endif }}
-			<a href="/software/" class="button no-bg medium align-right">
+			<a href="/software" class="button no-bg medium align-right">
 				All software projects <img src="/_themes/physiome/img/icon-grid.png" alt="" class="icon">
 			</a>			
 		</header><!-- end .page-header -->

--- a/_themes/physiome/partials/footer.html
+++ b/_themes/physiome/partials/footer.html
@@ -7,11 +7,11 @@
 			<nav id="footer-nav" class="clearfix">
 
 				<ul>
-					<li><a href="/about/">About</a></li>
-					<li><a href="/meetings/">Meetings</a></li>
-					<li><a href="/research/">Research</a></li>
-					<li><a href="/software/">Software</a></li>
-					<li><a href="/data-repositories/">Data repositories</a></li>
+					<li><a href="/about">About</a></li>
+					<li><a href="/meetings">Meetings</a></li>
+					<li><a href="/research">Research</a></li>
+					<li><a href="/software">Software</a></li>
+					<li><a href="/data-repositories">Data repositories</a></li>
 				</ul>
 				
 			</nav><!-- end #footer-nav -->

--- a/_themes/physiome/partials/header.html
+++ b/_themes/physiome/partials/header.html
@@ -15,7 +15,7 @@
 			{{ else }}
 			<li>
 			{{ endif }}
-				<a href="/about/">About</a>
+				<a href="/about">About</a>
 				<ul>
 					<li><a href="/about/a-brief-history">A brief history of the Physiome Project</a></li>
 					<li><a href="/about/molecules-to-humankind">From molecules to humankind</a></li>
@@ -32,7 +32,7 @@
 			{{ else }}
 			<li>
 			{{ endif }}
-				<a href="/meetings/">Meetings</a>
+				<a href="/meetings">Meetings</a>
 			</li>
 
 			{{ if segment_1  == "research" }}
@@ -40,7 +40,7 @@
 			{{ else }}
 			<li>
 			{{ endif }}
-				<a href="/research/">Research</a>
+				<a href="/research">Research</a>
 				<ul>
 	                <li><a href="/research/cardiovascular">Cardiovascular system</a></li>
 	                <li><a href="/research/urinary-kidney">Urinary system and kidney</a></li>
@@ -63,16 +63,16 @@
 			{{ else }}
 			<li>
 			{{ endif }}
-				<a href="/software/">Software</a>
+				<a href="/software">Software</a>
 				<ul>                	                   
-                    <li><a href="/software/opencmiss/">OpenCMISS</a></li>
-                    <li><a href="/software/opencmiss/iron/">OpenCMISS-Iron</a></li>
-                    <li><a href="/software/opencmiss/zinc/">OpenCMISS-Zinc</a></li>
-                    <li><a href="/software/opencmiss/cmgui/">Cmgui</a></li> 
-                    <li><a href="/software/cellml/">CellML</a></li>
-                    <li><a href="/software/fieldml/">FieldML</a></li>
-                    <li><a href="/software/opencell/">OpenCell</a></li> 
-                    <li><a href="/software/cm/">CM</a></li>
+                    <li><a href="/software/opencmiss">OpenCMISS</a></li>
+                    <li><a href="/software/opencmiss/iron">OpenCMISS-Iron</a></li>
+                    <li><a href="/software/opencmiss/zinc">OpenCMISS-Zinc</a></li>
+                    <li><a href="/software/opencmiss/cmgui">Cmgui</a></li> 
+                    <li><a href="/software/cellml">CellML</a></li>
+                    <li><a href="/software/fieldml">FieldML</a></li>
+                    <li><a href="/software/opencell">OpenCell</a></li> 
+                    <li><a href="/software/cm">CM</a></li>
 				</ul>
 			</li>
 
@@ -81,7 +81,7 @@
 			{{ else }}
 			<li>
 			{{ endif }}
-				<a href="/data-repositories/">Data repositories</a>
+				<a href="/data-repositories">Data repositories</a>
 				<ul>
 					<li><a href="/data-repositories/about">About repositories</a></li>
 					<li><a href="/data-repositories/physiome-model-repository">Physiome Model Repository</a></li>

--- a/_themes/physiome/templates/home.html
+++ b/_themes/physiome/templates/home.html
@@ -15,7 +15,7 @@
   	</li>
 
 	<li>
-	  <a href="/software/opencmiss/zinc/">
+	  <a href="/software/opencmiss/zinc">
 			<img src="/assets/img/software/zinclibrary/220x140/zinclibrary-bone.png" alt="">
 			<h5 class="title">OpenCMISS-Zinc</h5>
 			<span class="categories">&nbsp;</span>
@@ -23,7 +23,7 @@
   	</li>
 
 	<li>
-	  <a href="/software/cellml/">
+	  <a href="/software/cellml">
 			<img src="/assets/img/software/cellml/220x140/cell-diagram.png" alt="">
 			<h5 class="title">CellML</h5>
 			<span class="categories">&nbsp;</span>
@@ -31,7 +31,7 @@
   </li>
 
 	<li>
-	  <a href="software/fieldml/">
+	  <a href="software/fieldml">
 			<img src="/assets/img/software/fieldml/220x140/fieldml-bifurc.png" alt="">
 			<h5 class="title">FieldML</h5>
 			<span class="categories">&nbsp;</span>
@@ -39,7 +39,7 @@
   	</li>
 
 	<li>
-	  <a href="/software/opencell/">
+	  <a href="/software/opencell">
 			<img src="/assets/img/software/opencell/220x140/opencell-graph.png" alt="">
 			<h5 class="title">OpenCell</h5>
 			<span class="categories">&nbsp;</span>
@@ -47,7 +47,7 @@
   	</li>
 
 	<li>
-	  <a href="/software/opencmiss/cmgui/">
+	  <a href="/software/opencmiss/cmgui">
 			<img src="/assets/img/software/cmgui/220x140/cmgui-fitting.png" alt="">
 			<h5 class="title">Cmgui</h5>
 			<span class="categories">&nbsp;</span>
@@ -55,7 +55,7 @@
   	</li>
 
 	<li>
-		<a href="/software/zincplugin/">
+		<a href="/software/zincplugin">
 			<img src="/assets/img/software/zincplugin/220x140/zincplugin-hearts.png" alt="">
 			<h5 class="title">Zinc plugin</h5>
 			<span class="categories">&nbsp;</span>
@@ -63,7 +63,7 @@
   	</li>
 
 	<li>
-	  <a href="/software/cm/">
+	  <a href="/software/cm">
 			<img src="/assets/img/software/cm/220x140/leg-model.png" alt="">
 			<h5 class="title">CM</h5>
 			<span class="categories">&nbsp;</span>

--- a/_themes/physiome/templates/software-project-index-dynamic.html
+++ b/_themes/physiome/templates/software-project-index-dynamic.html
@@ -1,6 +1,6 @@
 <header class="page-header">
 	<h1 class="page-title align-left">{{ title }}</h1>			
-	<a href="/software/" class="button no-bg medium align-right">
+	<a href="/software" class="button no-bg medium align-right">
 		All software projects <img src="/_themes/physiome/img/icon-grid.png" alt="" class="icon">
 	</a>	
 	<hr />

--- a/_themes/physiome/templates/software-project-index.html
+++ b/_themes/physiome/templates/software-project-index.html
@@ -1,6 +1,6 @@
 <header class="page-header">
 	<h1 class="page-title align-left">{{ title }}</h1>			
-	<a href="/software/" class="button no-bg medium align-right">
+	<a href="/software" class="button no-bg medium align-right">
 		All software projects <img src="/_themes/physiome/img/icon-grid.png" alt="" class="icon">
 	</a>	
 	<hr />


### PR DESCRIPTION
Newer versions of Statamic do not match links to default pages ending in a slash.
e.g. /about/ does not work, /about does. Previously both would get about/page.
