### PR TITLE
Remove cmgui dev snapshot list retrieval from ftp

### DIFF
--- a/_content/04-software/01-opencmiss/03-cmgui/03-download/developer.md
+++ b/_content/04-software/01-opencmiss/03-cmgui/03-download/developer.md
@@ -12,17 +12,19 @@ navtitle: Download
 
 The following links are to development versions of Cmgui for Windows, Mac and Linux, plus source code. Be aware that development versions may have errors or incomplete features, and new features are subject to change. The latest official releases are available [here](/software/opencmiss/cmgui/download/) and include installation instructions relevant to these developer versions.
 
+Pre-built developer snapshots may be downloaded directly from the [listing of snapshots](https://ftp.bioeng.auckland.ac.nz/cmiss/zinclibrary/latest/)
+
 ### Windows 64-bit
 
-{{ filelist url="ftp://ftp.bioeng.auckland.ac.nz/cmiss/zinclibrary/latest/" releasefilter="cmgui" osfilter="windows" limit="4" }}
+<!-- filelist url="ftp://ftp.bioeng.auckland.ac.nz/cmiss/zinclibrary/latest/" releasefilter="cmgui" osfilter="windows" limit="4" -->
 
 ### Mac OS X
 
-{{ filelist url="ftp://ftp.bioeng.auckland.ac.nz/cmiss/zinclibrary/latest/" releasefilter="cmgui" osfilter="mac" limit="4" }}
+<!-- filelist url="ftp://ftp.bioeng.auckland.ac.nz/cmiss/zinclibrary/latest/" releasefilter="cmgui" osfilter="mac" limit="4" -->
 
 ### Ubuntu Linux 64-bit
 
-{{ filelist url="ftp://ftp.bioeng.auckland.ac.nz/cmiss/zinclibrary/latest/" releasefilter="cmgui" osfilter="ubuntu" limit="4" }}
+<!-- filelist url="ftp://ftp.bioeng.auckland.ac.nz/cmiss/zinclibrary/latest/" releasefilter="cmgui" osfilter="ubuntu" limit="4" -->
 
 ### Source code
 

--- a/_themes/physiome/partials/google-analytics.html
+++ b/_themes/physiome/partials/google-analytics.html
@@ -1,14 +1,9 @@
-<script type="text/javascript">
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-4M5LLYPVTY"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-35696129-1']);
-  _gaq.push(['_setDomainName', 'physiomeproject.org']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-
+  gtag('config', 'G-4M5LLYPVTY');
 </script>


### PR DESCRIPTION
This removes the retrieval of file list from ftp as the ftp access has been disabled, and the act of waiting for the connection to the server blocks loading and thus access to the rest of the site until timeout.